### PR TITLE
add caret as alternate keybinding for bol

### DIFF
--- a/src/input/keybindings.jl
+++ b/src/input/keybindings.jl
@@ -26,6 +26,7 @@ const _default_keybindings = Dict{Tuple{Union{Symbol, String}, Bool, Bool, Bool}
     ("<right>",    false, false, true ) => :fastright,
     ("<left>",     true,  false, false) => :bol,
     ("0",          false, false, false) => :bol,
+    ("^",          false, false, false) => :bol,
     ("<right>",    true,  false, false) => :eol,
     ("\$",         false, false, false) => :eol,
     ("u",          false, false, false) => :halfpageup,


### PR DESCRIPTION
for those who have ^ ingrained in their muscle memory.

see https://github.com/ronisbr/TerminalPager.jl/issues/27

