### PR TITLE
Use redirect_stdout to restore stdout

### DIFF
--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -15,7 +15,6 @@ PrecompileTools.@setup_workload begin
     old_stdout = Base.stdout
     redirect_stdout()
 
-    old_stdin = Base.stdin
     stdin_rd, stdin_wr = redirect_stdin()
 
     PrecompileTools.@compile_workload begin
@@ -66,6 +65,5 @@ PrecompileTools.@setup_workload begin
         write(stdin_wr, "q")
     end
 
-    Base.stdin  = old_stdin
-    Base.stdout = old_stdout
+    redirect_stdout(old_stdout)
 end


### PR DESCRIPTION
Attempt to fix #30 

Use `redirect_stdout` to restore stdout

I think (but I'm not sure) that stdin is already redirected from TTY, so restoring stdin seems unnecessary, and caused error with `redirect_stdin(old_stdin)`

I'm not confident that this is correct, but it seems to compile and pass tests locally for me on both Julia v1.6.7 and Julia v1.9.3.
Would recommend a review from someone who understands this stuff.