### PR TITLE
Correctly interpolate symbols into `@help`

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -25,7 +25,7 @@ macro help(f)
         # We do not need to verify if we are in a interactive environment because this mode is
         # only accessible through pager mode, which already checks it.
         try
-            pager(TerminalPager._get_help($f_str); use_alternate_screen_buffer = true)
+            $TerminalPager.pager($TerminalPager._get_help($f_str); use_alternate_screen_buffer = true)
         catch err
             Base.display_error(stderr, err, Base.catch_backtrace())
         end


### PR DESCRIPTION
Especially in `startup.jl` some people prefer to only bring the symbols into `Main` which are really used. I have for example (shortened version)
```julia
    BasicAutoloads.register_autoloads([
        ["@help"] => :(using TerminalPager: @help),
    ])
```
in my `startup.jl`, but everyone who would have `using TerminalPager: @help` in their `startup.jl` or issued this command in their REPL were affected, too, by the following issue:

`@help` assumes, that the `pager` function and the `TerminalPager` module are known in the calling module (because the expression returned by `@help` is evaluated there). This assumption is wrong (see above) and unnecessary. We can interpolate them into the expression within `@help` (because `@help` is defined in the module `TerminalPager` and there both `pager` and `TerminalPager` are known symbols), to always work correctly independent of the user `using` all the symbols.