### PR TITLE
Use the correct module for the `err` variable for v1.10+

### DIFF
--- a/src/repl.jl
+++ b/src/repl.jl
@@ -246,14 +246,10 @@ function _tp_mode_do_cmd(repl::REPL.AbstractREPL, input::String)
 
             # If we have an error, print the information and stop the processing.
             if is_error
-                @static if VERSION >= v"1.9"
-                    val = Base.scrub_repl_backtrace(val)
-                    Base.istrivialerror(val) || setglobal!(Main, :err, val)
-                    Base.invokelatest(Base.display_error, repl.t.err_stream, val)
-                    break
-                else
-                    Base.invokelatest(Base.display_error, repl.t.err_stream, val)
-                end
+                val = Base.scrub_repl_backtrace(val)
+                Base.istrivialerror(val) || setglobal!(Base.MainInclude, :err, val)
+                Base.invokelatest(Base.display_error, repl.t.err_stream, val)
+                break
             end
 
             # If the user added `;` at the end of the command, we should not show the


### PR DESCRIPTION
When in pager mode, if an error occurs, instead of the actual error we get this error:

```julia
pager> Int(1.1)
ERROR: cannot assign a value to imported variable MainInclude.err from module Main
Stacktrace:
 [1] _tp_mode_do_cmd(repl::REPL.LineEditREPL, input::String)
   @ TerminalPager ~/foss/TerminalPager.jl/src/repl.jl:251
```

I've encountered this several times and had to exit pager mode just because of this (and then rerun the erroring code to see the actual error), but today I decided to look into the cause. Thankfully it turned out to be rather simple: it's because the module that `err` belongs to changed from `Main` to `Base.MainInclude` in https://github.com/JuliaLang/julia/pull/48308 which is in Julia v1.10 and above. 

Since now the package compat is only for Julia 1.10 and above anyway, this PR removes the code for the older versions and changes the error handling code to use the right module for these supported Julia versions (which is `Base.MainInclude`). 