### PR TITLE
Adjust AST eval call to work with (upcoming) minor REPL refactor

### DIFF
--- a/src/repl.jl
+++ b/src/repl.jl
@@ -239,10 +239,14 @@ function _tp_mode_do_cmd(repl::REPL.AbstractREPL, input::String)
             # If the command is incomplete, we need to wait for another line.
             !isnothing(ast) && ast.head == :incomplete && continue
 
-            # We will use `REPL.eval_with_backend` to evaluate the expression. This function
-            # returns two values: the object returned by the expression, and a boolean value
-            # indicating if we got an error.
-            val, is_error = REPL.eval_with_backend(ast, REPL.backend(repl))
+	    # We will use `REPL.eval_on_backend` (called `REPL.eval_with_backend` pre-1.12)
+	    # to evaluate the expression. This function returns two values: the object
+	    # returned by the expression, and a boolean value indicating if we got an error.
+	    @static if VERSION >= v"1.12-beta4"
+		    val, is_error = REPL.eval_on_backend(ast, REPL.backend(repl))
+	    else
+		    val, is_error = REPL.eval_with_backend(ast, REPL.backend(repl))
+	    end
 
             # If we have an error, print the information and stop the processing.
             if is_error


### PR DESCRIPTION
On Julia nightly, trying to run anything in pager mode gives an error: 

```
julia> VERSION
v"1.13.0-DEV.690"

pager> x = 1
ERROR: UndefVarError: `eval_with_backend` not defined in `REPL`
Suggestion: check for spelling errors or missing imports.
Stacktrace:
 [1] getproperty
   @ ./Base_compiler.jl:50 [inlined]
 [2] _tp_mode_do_cmd(repl::REPL.LineEditREPL, input::String)
   @ TerminalPager ~/foss/TerminalPager.jl/src/repl.jl:245
```

This is due to https://github.com/JuliaLang/julia/pull/58414 that removed the `REPL.eval_with_backend` function. The method for evaluating ASTs is now called `eval_on_backend`. 

This change is also being backported to Julia 1.12 and will appear with `v1.12-beta4`: [JuliaLang/julia@`c585f7e` (#58369)](https://github.com/JuliaLang/julia/pull/58369/commits/c585f7ee7075cabf048f9d945fcfbf4f9bdccca3), so it seems like this error will start happening on 1.12 also. 

(The original PR 58414 is tagged as `backport 1.11` also, but there don't seem to be any commits that do that backport. The version number checks will get a bit messier if that does happen in the future.) 

This PR uses the correct method name according to the Julia version. With this change: 

```julia
julia> VERSION
v"1.13.0-DEV.690"

julia> using TerminalPager

pager> x = 1
1
```