### PR TITLE
Non standard string literals

### DIFF
--- a/src/help_keybinding.jl
+++ b/src/help_keybinding.jl
@@ -26,7 +26,7 @@ It returns an empty string otherwise.
 function _extract_identifier(input::AbstractString, cursor_pos::Integer)::String
     isempty(strip(input)) && return ""
 
-    _to_string(x::SyntaxNode) = kind(x) == K"." ? input[_range(x)] : Base.string(x)
+    _to_string(x::SyntaxNode) = kind(x) == K"." ? input[_range(x)] : string(x)
 
     # Get the syntax node the cursor is on.
     node = _find_cursor_node(_tryparsestmt(input), cursor_pos)
@@ -189,7 +189,7 @@ function _range(x::SyntaxNode)
 end
 
 """
-_tryparsestmt(x) -> SyntaxNode
+    _tryparsestmt(x) -> SyntaxNode
 
 Try to parse `x` into a `SyntaxNode`. If there are errors or warnings, they are ignored.
 """

--- a/test/internals/help_key_binding.jl
+++ b/test/internals/help_key_binding.jl
@@ -71,4 +71,14 @@ using TerminalPager: _extract_identifier
     @test _extract_identifier("Base.@time", 6) == "Base.@time" # cursor on '@time'
 
     @test _extract_identifier("InteractiveUtils.@code_lowered(debuginfo=:none, ", 48) == "InteractiveUtils.@code_lowered"
+
+    # == Non-Standard String Literals ======================================================
+
+    @test _extract_identifier("r\"abc\"", 1)  == "@r_str" # cursor on 'r'
+    @test _extract_identifier("r\"abc\"", 2)  == "@r_str" # cursor on first '"'
+    @test _extract_identifier("r\"abc\"", 3)  == "@r_str" # cursor on 'a'
+    @test _extract_identifier("r\"abc\"", 4)  == "@r_str" # cursor on 'b'
+    @test _extract_identifier("r\"abc\"", 5)  == "@r_str" # cursor on 'c'
+    @test _extract_identifier("r\"abc\"", 6)  == "@r_str" # cursor on second '"'
+    @test _extract_identifier("r\"abc\" ", 7) == "@r_str" # cursor after non-standard string literal
 end


### PR DESCRIPTION
Show meaningful documentation when the cursor is on or after something like `r"abc"`.