### PR TITLE
Rewrite inline help to support keywords

### DIFF
--- a/src/TerminalPager.jl
+++ b/src/TerminalPager.jl
@@ -1,11 +1,18 @@
 module TerminalPager
 
+# The code implementing the inline help triggered by a shortcut accesses the following
+# private identifiers in addition to various field accesses. This is not ideal, but
+# neither JuliaSyntax nor REPL.LineEdit seem to provide a public API for this. This means
+# `TerminalPager.jl` is strongly coupled with `JuliaSyntax.jl` and `REPL.jl`.
+using Base.JuliaSyntax
+using Base.JuliaSyntax: is_keyword, @KSet_str, sourcetext, span
+
 using REPL
 using REPL.LineEdit
+using REPL.LineEdit: buffer, input_string
 
 using Crayons
 using InteractiveUtils
-using Base.JuliaSyntax
 using Preferences
 using StringManipulation
 

--- a/test/internals/help_key_binding.jl
+++ b/test/internals/help_key_binding.jl
@@ -54,7 +54,10 @@ end
 
     # == Test Qualified Identifiers in Module Expressions ==================================
 
-    test("Base.Core.stdout")
+    # AST changed between 1.11 and 1.12, i.e. this is only supported 1.12 onwards.
+    @static if VERSION >= v"1.12-"
+        test("Base.Core.stdout")
+    end
 
     # Base.JuliaSyntax.byte_range
 


### PR DESCRIPTION
This is a redesign of the feature with a clear architecture. It not only handles keywords, it should also work with generic UTF-8 identifiers. A lot more test cases are added, where a large amount is auto-generated on the fly.

If cases happen which are not explicitly covered, we at least try to do something useful. Nevertheless, this certainly needs to be improved when more test cases come up.