### PR TITLE
🔧 Fix function names used with `@help`

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -18,16 +18,10 @@ julia> @help write
 ```
 """
 macro help(f)
-    # Get the string representation of `f`. Notice that we need to remove the quotes added
-    # by `sprint` when `f` is a string.
-    local f_str
-    f_str = sprint(show, f)
-    f_str = chopprefix(f_str, "\"")
-    f_str = chopsuffix(f_str, "\"")
-
-    # When calling @help for a macro, the argument `f` will get prefixed with a block comment.
-    # We remove that comment and just keep the macro name.
-    f_str = chopprefix(f_str, r"#= .+ =# ")
+    # Get the string representation of `f`.
+    # When calling @help for a macro, the resulting `Expr` contains a `LineNumberNode`
+    # jumbling the resulting string, so use the `Symbol` instead.
+    f_str = string(Meta.isexpr(f, :macrocall) ? f.args[1] : f)
 
     ex_out = quote
         # We do not need to verify if we are in a interactive environment because this mode is


### PR DESCRIPTION
Handling the `macrocall` within the `Expr` instead of within the `String` simplifies the logic. Additionally, as `f_str` is evaluated at macro expansion time and not inside the quote, macro hygiene does not apply for it.

Fixes: #62 