### PR TITLE
Fix help on complex expressions

### DIFF
--- a/src/help_keybinding.jl
+++ b/src/help_keybinding.jl
@@ -62,7 +62,13 @@ function _collaterate(input::String, cursor_pos::Integer)
         search_index = prevind(input, search_index)
     end
 
-    return search_index
+    # If the cursor is at the end of the input without trailing space, refer to the last
+    # identifier.
+    if search_index == ncodeunits(input) + 1 && !isspace(input[end])
+        return search_index - 1
+    else
+        return search_index
+    end
 end
 
 """

--- a/test/internals/help_key_binding.jl
+++ b/test/internals/help_key_binding.jl
@@ -10,6 +10,7 @@ const Mapping = Pair{String, String}
 
 # Per defined test, we should check multiple cursor positions. This automates the tests.
 test(input, i::Integer, result) = @eval @test _extract_identifier($input, $i) == $result
+test(x, result) = test(x, length(x)+1, result) # test at end of input
 test(x::Mapping) = [test(x.first, i, x.second) for i in 1 : length(x.first)+1]
 test(x::String) = test(x => x)
 
@@ -71,9 +72,7 @@ end
     test("@time sin(x)", ["@time " => "@time", "sin(" => "sin", "x" => "x"])
 
     # Test that the cursor after the macro argument provides help about the macro.
-    let s = "@code_native syntax=:intel "
-        test(s, length(s)+1, "@code_native")
-    end
+    test("@code_native syntax=:intel ", "@code_native")
 
     # == Module Qualified Macros ===========================================================
 
@@ -250,4 +249,8 @@ end
             "⫸" => "⫸"
         ]
     )
+
+    # == Real World Examples ===============================================================
+
+    test("cl.platform().id |> unsafe_string", "unsafe_string")
 end


### PR DESCRIPTION
If the cursor is visually at the end of a token (i.e. one position after it), the token is meant for help. The macro use case has a trailing space.