### PR TITLE
🩹 Deactivate test with known JuliaSyntax.jl bug

### DIFF
--- a/test/internals/help_key_binding.jl
+++ b/test/internals/help_key_binding.jl
@@ -96,7 +96,7 @@ end
     test("break")
     test("const")
     test("continue")
-    test("do")
+    @static VERSION <= v"1.13-" && test("do") # Deactivate test until https://github.com/JuliaLang/JuliaSyntax.jl/issues/599 is fixed.
     test("export")
     test("for")
     test("function")


### PR DESCRIPTION
This throws on nightly so that it is harder to see real problems in TerminalPager.jl. The problem should be fixed in JuliaSyntax.jl, so is not fully actionable in TerminalPager.jl.

This should be reverted when [https://github.com/JuliaLang/JuliaSyntax.jl/issues/599](https://github.com/JuliaLang/JuliaSyntax.jl/issues/599) is fixed.