### PR TITLE
🔧 Implement more robust shortcut registration

### DIFF
--- a/src/help_keybinding.jl
+++ b/src/help_keybinding.jl
@@ -153,7 +153,7 @@ function _register_help_shortcuts(repl)
 
         # Register the keybindings both in the regular REPL mode (always the first one)
         # and in the pager mode (which is the last one, as we just added it).
-        for m in (repl.interface.modes[1], repl.interface.modes[end])
+        for m in repl.interface.modes |> Ref .|> (first, last)
             escapes = m.keymap_dict['\e']
             escapes['O']['P'] = _show_pager_extended_help  # <F1>
             escapes['h']      = _show_pager_extended_help  # <Alt> + h


### PR DESCRIPTION
For all I know the previous code is currently working as intended. However, strictly speaking, we do not know which indices REPL uses. We are only interested in the first and the last element, so now the code matches the documentation. While we are at it, we can avoid repeating ourself and highlight the fact that we are operating on only one iterable.