### PR TITLE
Fix loading on 1.14 due to REPL function removal

### DIFF
--- a/src/repl.jl
+++ b/src/repl.jl
@@ -57,7 +57,11 @@ function _create_pager_repl_mode(repl::REPL.AbstractREPL, main::LineEdit.Prompt)
     prefix_prompt, prefix_keymap = LineEdit.setup_prefix_keymap(hp, tp_mode)
 
     # We also want to support reverse searching.
-    search_promt, skeymap = LineEdit.setup_search_keymap(hp)
+    skeymap = @static if VERSION >= v"1.13-"
+        LineEdit.history_keymap
+    else
+        LineEdit.setup_search_keymap(hp)[2]
+    end
 
     # Key mappings used in the pager mode:
     mk = REPL.mode_keymap(main)
@@ -133,7 +137,11 @@ function _create_pager_help_repl_mode(
     prefix_prompt, prefix_keymap = LineEdit.setup_prefix_keymap(hp, tp_mode)
 
     # We also want to support reverse searching.
-    search_promt, skeymap = LineEdit.setup_search_keymap(hp)
+    skeymap = @static if VERSION >= v"1.13-"
+        LineEdit.history_keymap
+    else
+        LineEdit.setup_search_keymap(hp)[2]
+    end
 
     # Key mappings used in the pager mode:
     mk = REPL.mode_keymap(main)


### PR DESCRIPTION
[The REPL history rework](https://github.com/JuliaLang/julia/pull/59819/files) removed `LineEdit.setup_search_keymap`. `LineEdit.history_keymap` looks a bit similar, so use this instead for 1.14.

This allows using the inline help again with nightly. However, the rest is completely untested, as I do not know this code and do not know what it should do.

If this should break some functionality on 1.14, it can be fixed in a follow-up. But this is still better than having no functionality at all on 1.14 as the package does not load.

Error message before the fix:
```
ERROR: LoadError: UndefVarError: `setup_search_keymap` not defined in `REPL.LineEdit`
Suggestion: check for spelling errors or missing imports.
Stacktrace:
  [1] getproperty
    @ ./Base_compiler.jl:50 [inlined]
  [2] _create_pager_help_repl_mode(repl::REPL.LineEditREPL, main::REPL.LineEdit.Prompt, tp_mode::REPL.LineEdit.Prompt)
    @ TerminalPager ~/.julia/packages/TerminalPager/0kM9N/src/repl.jl:136
  [3] _create_pager_repl_mode(repl::REPL.LineEditREPL, main::REPL.LineEdit.Prompt)
    @ TerminalPager ~/.julia/packages/TerminalPager/0kM9N/src/repl.jl:52
  [4] _init_pager_repl_mode(repl::REPL.LineEditREPL)
    @ TerminalPager ~/.julia/packages/TerminalPager/0kM9N/src/repl.jl:163
  [5] macro expansion
    @ ~/.julia/packages/TerminalPager/0kM9N/src/precompilation.jl:24 [inlined]
  [6] macro expansion
    @ ~/.julia/packages/PrecompileTools/gn08A/src/workloads.jl:73 [inlined]
  [7] macro expansion
    @ ~/.julia/packages/TerminalPager/0kM9N/src/precompilation.jl:17 [inlined]
  [8] macro expansion
    @ ~/.julia/packages/PrecompileTools/gn08A/src/workloads.jl:121 [inlined]
  [9] top-level scope
    @ ~/.julia/packages/TerminalPager/0kM9N/src/precompilation.jl:118
 [10] include(mapexpr::Function, mod::Module, _path::String)
    @ Base ./Base.jl:310
 [11] top-level scope
    @ ~/.julia/packages/TerminalPager/0kM9N/src/TerminalPager.jl:179
 [12] include(mod::Module, _path::String)
    @ Base ./Base.jl:309
 [13] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)
    @ Base ./loading.jl:3148
 [14] top-level scope
    @ stdin:5
 [15] eval(m::Module, e::Any)
    @ Core ./boot.jl:489
 [16] include_string(mapexpr::typeof(identity), mod::Module, code::String, filename::String)
    @ Base ./loading.jl:2994
 [17] include_string
    @ ./loading.jl:3004 [inlined]
 [18] exec_options(opts::Base.JLOptions)
    @ Base ./client.jl:342
 [19] _start()
    @ Base ./client.jl:577
```