### PR TITLE
Replace adjoint and rand in precompilation.jl with Base equivalents

### DIFF
--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -25,7 +25,7 @@ PrecompileTools.@setup_workload begin
         _init_pager_repl_mode(mock_repl)
         _register_help_shortcuts(mock_repl)
 
-        a = vcat(fill(0.1986, 100)', rand(100, 100))
+        a = vcat(reshape(fill(0.1986, 100), 1, :), zeros(100, 100))
         t = @async pager(a)
 
         # Ruler.


### PR DESCRIPTION
Hi, thanks for the package!

In `src/precompilation.jl:28`, two functions are used that are not in `Base`:

- `adjoint(::AbstractVecOrMat)`, defined in `LinearAlgebra`
- `rand(::Int64, ::Int64)`, defined in `Random`

In a normal Julia session this is fine since the default sysimage includes both. However, when using [`create_app`](https://julialang.github.io/PackageCompiler.jl/dev/apps.html#Creating-an-app) with `incremental=false`, the default sysimage is dropped and only packages listed in `Project.toml` are available. Since neither `LinearAlgebra` or `Random` are explicit dependencies, compiling the app fails:

```julia
❯ julia --project=@PackageCompiler -q
julia> using PackageCompiler

julia> create_app("TerminalPager.jl","TerminalPagerBin")
PackageCompiler: bundled libraries:
  ├── Base:
  │    ├── libLLVM.so.18.1jl - 105.521 MiB
  │    ├── libatomic.so.1.2.0 - 159.875 KiB
  │    ├── libdSFMT.so - 21.602 KiB
  │    ├── libgcc_s.so.1 - 892.930 KiB
  │    ├── libgfortran.so.5.0.0 - 9.553 MiB
  │    ├── libgmp.so.10.5.0 - 707.688 KiB
  │    ├── libgmpxx.so.4.7.0 - 36.445 KiB
  │    ├── libgomp.so.1.0.0 - 1.469 MiB
  │    ├── libjulia-codegen.so.1.12.5 - 77.437 MiB
  │    ├── libjulia-internal.so.1.12.5 - 14.130 MiB
  │    ├── libmpfr.so.6.2.2 - 2.406 MiB
  │    ├── libopenlibm.so.4.0 - 248.109 KiB
  │    ├── libpcre2-8.so.0.13.0 - 663.234 KiB
  │    ├── libquadmath.so.0.0.0 - 966.984 KiB
  │    ├── libssp.so.0.0.0 - 35.555 KiB
  │    ├── libstdc++.so.6.0.34 - 2.561 MiB
  │    ├── libunwind.so.8.1.0 - 504.258 KiB
  │    ├── libuv.so.2.0.0 - 656.695 KiB
  │    ├── libz.so.1.3.1 - 116.062 KiB
  │    ├── libjulia.so.1.12.5 - 246.602 KiB
  ├── Stdlibs:
  │   ├── OpenBLAS_jll
  │   │   ├── libopenblas64_.0.3.29.so - 34.150 MiB
  │   ├── libblastrampoline_jll
  │   │   ├── libblastrampoline.so.5 - 3.418 MiB
  │   ├── OpenSSL_jll
  │   │   ├── libcrypto.so.3 - 6.309 MiB
  │   │   ├── libssl.so.3 - 1.263 MiB
  Total library file size: 263.351 MiB
✔ [07m:22s] PackageCompiler: creating compiler sysimage (incremental=false)
⠸ [04m:27s] PackageCompiler: compiling fresh sysimage (incremental=false)
Precompiling Pkg finished.
  1 dependency successfully precompiled in 59 seconds
  ✗ TerminalPager
Precompiling packages finished.
  8 dependencies successfully precompiled in 18 seconds. 7 already precompiled.

ERROR: The following 1 direct dependency failed to precompile:

TerminalPager

Failed to precompile TerminalPager [0c614874-6106-40ed-a7c2-2f1cd0bff883] to "/home/sandy/.julia/compiled/v1.12/TerminalPager/jl_AN6qR9".
ERROR: LoadError: MethodError: no method matching adjoint(::Vector{Float64})
The function `adjoint` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  adjoint(::Missing)
   @ Base missing.jl:101
  adjoint(::Number)
   @ Base number.jl:225

Stacktrace:
  [1] macro expansion
    @ ~/docs/forks/TerminalPager.jl/src/precompilation.jl:28 [inlined]
  [2] macro expansion
    @ ~/.julia/packages/PrecompileTools/gn08A/src/workloads.jl:73 [inlined]
  [3] macro expansion
    @ ~/docs/forks/TerminalPager.jl/src/precompilation.jl:18 [inlined]
  [4] macro expansion
    @ ~/.julia/packages/PrecompileTools/gn08A/src/workloads.jl:121 [inlined]
  [5] top-level scope
    @ ~/docs/forks/TerminalPager.jl/src/precompilation.jl:118
  [6] include(mapexpr::Function, mod::Module, _path::String)
    @ Base ./Base.jl:307
  [7] top-level scope
    @ ~/docs/forks/TerminalPager.jl/src/TerminalPager.jl:179
  [8] include(mod::Module, _path::String)
    @ Base ./Base.jl:306
  [9] include_package_for_output(pkg::Base.PkgId, input::String, depot_path::Vector{String}, dl_load_path::Vector{String}, load_path::Vector{String}, concrete_deps::Vector{Pair{Base.PkgId, UInt128}}, source::Nothing)
    @ Base ./loading.jl:3024
 [10] top-level scope
    @ stdin:5
 [11] eval(m::Module, e::Any)
    @ Core ./boot.jl:489
 [12] include_string(mapexpr::typeof(identity), mod::Module, code::String, filename::String)
    @ Base ./loading.jl:2870
 [13] include_string
    @ ./loading.jl:2880 [inlined]
 [14] exec_options(opts::Base.JLOptions)
    @ Base ./client.jl:315
 [15] _start()
    @ Base ./client.jl:550
in expression starting at /home/sandy/docs/forks/TerminalPager.jl/src/precompilation.jl:9
in expression starting at /home/sandy/docs/forks/TerminalPager.jl/src/TerminalPager.jl:1
in expression starting at stdin:

*** output truncated ***
```

The fix is simply to use Base only functions for precompilation, and then `compile_app` works nicely
