### PR TITLE
✨ Provide help for bindings of REPL's active module

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -98,7 +98,10 @@ end
 ############################################################################################
 
 # Return the rendered help string of the function `f`.
-function _get_help(f::AbstractString)
+#
+# The help expression is evaluated in the REPL's active module by default, falling back to
+# `Main` if the binding is not found there. See issue #90.
+function _get_help(f::AbstractString, mod::Module = Base.active_module())
     # Create a buffer that will replace `stdout`.
     buf = IOBuffer()
     io = IOContext(
@@ -107,13 +110,16 @@ function _get_help(f::AbstractString)
         :limit => false,
     )
 
-    # Get the AST that generates the help.
-    ast = Base.invokelatest(TerminalPager.REPL.helpmode, io, f)
-
     # Evaluate the AST, which returns a Markdown object.
-    #
-    # If we are precompiling, just return a sample markdown.
     response = if ccall(:jl_generating_output, Cint, ()) == 1
+        # If we are precompiling, just return a sample markdown. We still invoke
+        # `REPL.helpmode` so that it gets precompiled via the precompile workload, but
+        # skip `Core.eval` because evaluating the resulting AST into a module during
+        # precompilation is not desirable. The `mod` argument does not affect which method
+        # instance is compiled (`Module` is a concrete type), so we simply let `helpmode`
+        # use its default.
+        Base.invokelatest(TerminalPager.REPL.helpmode, io, f)
+
         md"""
         # Header
 
@@ -126,21 +132,39 @@ function _get_help(f::AbstractString)
         ---
         """
     else
+        # Try the REPL's active module first. If the binding cannot be resolved there,
+        # fall back to `Main`, matching what the plain REPL would do. `REPL.helpmode`
+        # behaves differently for the two "missing binding" cases we care about:
+        #
+        #   - Unqualified bindings missing in `mod` (e.g. `foo` when `foo` only exists in
+        #     `Main`): it does **not** throw, but returns a "No documentation found"
+        #     Markdown. We detect this and retry with `Main`.
+        #   - Qualified bindings referencing a non-existing module (e.g. `Foo.bar` when
+        #     `Foo` is undefined): it throws `UndefVarError`, which we catch and retry
+        #     with `Main`.
+        #
+        # In both cases, if `Main` also cannot resolve the binding, we return a Markdown
+        # object mimicking the REPL's "no documentation found" output instead of
+        # propagating any error.
         try
-            Core.eval(Main, ast)
+            response = _eval_helpmode(io, f, mod)
+            if mod !== Main && _is_not_found_response(response)
+                try
+                    response = _eval_helpmode(io, f, Main)
+                catch err
+                    err isa UndefVarError || rethrow()
+                end
+            end
+            response
         catch err
-            # Evaluating the help AST can fail, for example, when the user asks for help
-            # on a qualified name whose module does not exist (e.g. `@help Foo.bar` where
-            # `Foo` is not defined). In those cases, return a Markdown object that mimics
-            # REPL's own "no documentation found" output instead of propagating the error.
-            # We don't want to just forward to `?help`, as this also throws an error in
-            # this case.
-            if err isa UndefVarError
+            err isa UndefVarError || rethrow()
+            try
+                mod === Main ? rethrow() : _eval_helpmode(io, f, Main)
+            catch err2
+                err2 isa UndefVarError || rethrow()
                 Markdown.parse(
                     "No documentation found.\n\nBinding `$(lstrip(f, '?'))` does not exist."
                 )
-            else
-                rethrow()
             end
         end
     end
@@ -154,4 +178,19 @@ function _get_help(f::AbstractString)
     close(io)
 
     return str
+end
+
+# Run `REPL.helpmode` for `f` in `mod` and evaluate the resulting AST in `mod`.
+function _eval_helpmode(io::IO, f::AbstractString, mod::Module)
+    ast = Base.invokelatest(TerminalPager.REPL.helpmode, io, f, mod)
+    return Core.eval(mod, ast)
+end
+
+# Return `true` if `response` is the "No documentation found" Markdown object produced by
+# `REPL.helpmode` when the queried binding does not exist in the evaluated module.
+function _is_not_found_response(response)
+    response isa Markdown.MD && !isempty(response.content) || return false
+    first = response.content[1]
+    first isa Markdown.Paragraph || return false
+    return first.content == ["No documentation found."]
 end

--- a/src/repl.jl
+++ b/src/repl.jl
@@ -318,30 +318,9 @@ function _tp_help_mode_do_cmd(repl::REPL.AbstractREPL, input::String)
     # We do not need to verify if we are in a interactive environment because this mode is
     # only accessible through pager mode, which already checks it.
     try
-        # Create a buffer that will replace `stdout`.
-        buf = IOBuffer()
-        io = IOContext(
-            IOContext(buf, stdout),
-            :displaysize => displaysize(stdout),
-            :limit => false,
-        )
-
-        # Get the AST that generates the help.
-        ast = Base.invokelatest(REPL.helpmode, io, input)
-
-        # Evaluate the AST, which returns a Markdown object.
-        response = Core.eval(Main, ast)
-
-        # Render the output.
-        show(io, MIME("text/plain"), response)
-        write(io, '\n')
-
         # Take everything and display in the pager using the alternate screen buffer to
         # avoid modifying the current screen state.
-        pager(String(take!(buf)); use_alternate_screen_buffer = true)
-
-        close(io)
-
+        pager(_get_help(input); use_alternate_screen_buffer = true)
     catch err
         Base.display_error(repl.t.err_stream, err, Base.catch_backtrace())
     end

--- a/test/internals/help.jl
+++ b/test/internals/help.jl
@@ -39,3 +39,53 @@ using TerminalPager: _get_help
     @test str isa AbstractString
     @test occursin("Perhaps you meant eachindex", str)
 end
+
+# Tests for evaluating help in a specific module (see issue #90). Define a module with a
+# documented binding to check that `_get_help` looks in the given module, and separately
+# document a `Main`-level function to check the fallback from a non-`Main` active module.
+module HelpModuleTest
+    """
+        local_documented_function()
+
+    This is the documentation of a function local to `HelpModuleTest`.
+    """
+    local_documented_function() = 1
+end
+
+"""
+    main_only_documented_function()
+
+This is the documentation of a function defined in `Main`.
+"""
+main_only_documented_function() = 1
+
+@testset "Module-specific help" begin
+    # Binding defined in the given module: should return its documentation.
+    str = _get_help("local_documented_function", HelpModuleTest)
+    @test occursin("function local to", str)
+    @test occursin("HelpModuleTest", str)
+
+    # Binding only defined in `Main` but queried in a different module: `REPL.helpmode`
+    # does not throw in this case (it returns a "No documentation found" Markdown), so we
+    # must detect that and fall back to `Main` to provide the user with a useful result.
+    str = _get_help("main_only_documented_function", HelpModuleTest)
+    @test occursin("function defined in", str)
+    @test occursin("Main", str)
+
+    # Qualified identifier in a non-existing module, evaluated in a non-`Main` module:
+    # should not throw and should return a "not found" message. This exercises the
+    # `UndefVarError` fallback path to `Main`.
+    str = _get_help("ModuleDoesNotExist.anything", HelpModuleTest)
+    @test occursin("No documentation found", str)
+
+    # When `mod === Main` and the binding is missing, we must still produce the fallback
+    # Markdown rather than propagating an error.
+    str = _get_help("ModuleDoesNotExist.anything", Main)
+    @test occursin("No documentation found", str)
+
+    # A genuinely non-existing binding, queried from a non-`Main` module: the fallback to
+    # `Main` also cannot find it, so the result should still be "not found" (not an
+    # error).
+    str = _get_help("binding_that_does_not_exist_anywhere", HelpModuleTest)
+    @test occursin("No documentation found", str)
+end


### PR DESCRIPTION
When the user switched the REPL's active module (e.g. with `<alt>`+`<m>`) and has bindings with docstrings in this module which are undefined or differently defined in `Main`, `@help` and the inline help now also provide help for these bindings.

Care has been taken, that we do not regress, so that we still provide help to bindings which are defined in `Main`, but are undefined in the active module.

This is both a feature (supporting help in more cases) and a bugfix if e.g. an identically named function (not only a method) has been defined both in the active module and in `Main`.

This sounded simpler than it actually was, because of REPL's inconsistency to only sometimes throw when no binding is found.

Additionally, this change would have been needed in two places. Luckily, it was possible to write the code such that it can be (re-)used from both callers.

Fixes #90